### PR TITLE
Separation of weight and synaptic time constant

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -35,13 +35,13 @@ class Analytics(object):
 
     def add_to_file(self, dic):
         '''Adds data to h5 file, with data and path specified in dict.'''
-        self.file_base = os.getcwd()+'/'+self.params['datafile']
+        self.file_base = os.getcwd()+'/'+self.datafile
         h5.add_to_h5(self.file_base, {self.param_hash: dic}, 
                      'a', overwrite_dataset=True)
 
     def read_from_file(self, path):
         '''Reads data from h5 file at location path.'''
-        self.file_base = os.getcwd()+'/'+self.params['datafile']
+        self.file_base = os.getcwd()+'/'+self.datafile
         path_base = '/' + self.param_hash + '/' 
         data = h5.load_h5(self.file_base, path_base + path)
         return data
@@ -85,12 +85,12 @@ class Analytics(object):
     def firing_rates_integration(self):
         '''Returns vector of population firing rates in Hz.'''
         print 'Calculate firing rates.'
-        fac = self.params['tauf'] / self.params['C']
+        fac = self.tauf / self.C
         # conversion from ms to s
-        taum = self.params['taum'] * 1e-3            
-        tauf = self.params['tauf'] * 1e-3           
-        taur = self.params['taur'] * 1e-3           
-        dV =  self.params['Vth'] - self.params['V0']
+        taum = self.taum * 1e-3
+        tauf = self.tauf * 1e-3
+        taur = self.taur * 1e-3
+        dV =  self.Vth - self.V0
         rate_function = lambda mu, sigma: siegert.nu0_fb433(
             taum, tauf, taur, dV, 0., mu, sigma)
 

--- a/analytics.py
+++ b/analytics.py
@@ -85,7 +85,7 @@ class Analytics(object):
     def firing_rates_integration(self):
         '''Returns vector of population firing rates in Hz.'''
         print 'Calculate firing rates.'
-        fac = 1 / (self.params['C'])
+        fac = self.params['tauf'] / self.params['C']
         # conversion from ms to s
         taum = self.params['taum'] * 1e-3            
         tauf = self.params['tauf'] * 1e-3           
@@ -161,8 +161,9 @@ class Analytics(object):
         """Returns transfer functions for all populations."""
         trans_func = []
         for i in range(self.dimension):
-            mu = self.mu[i]*self.taum*1e-3/self.C 
-            sigma = np.sqrt(self.var[i]*self.taum*1e-3)/self.C
+            fac = self.tauf / self.C
+            mu = self.mu[i]*self.taum*1e-3*fac
+            sigma = np.sqrt(self.var[i]*self.taum*1e-3)*fac
             label = str(mu)+str(sigma)
             label += str(self.fmin)+str(self.fmax)+str(self.df)
 

--- a/params_circuit.py
+++ b/params_circuit.py
@@ -50,7 +50,7 @@ def get_data_microcircuit(new_params={}):
     # defined above, truncation at zero)
     params['delay_dist'] = 'none'
     # PSC amplitude in pA
-    params['w'] = 87.8*0.5
+    params['w'] = 87.8
 
     ### Connectivity 
     # indegrees

--- a/setup.py
+++ b/setup.py
@@ -77,13 +77,13 @@ class Setup(object):
         """
         new_vars = {}
         if circ.params['tf_mode'] == 'analytical':
-            new_vars['M'] = circ.params['I']*circ.params['W']
+            new_vars['M'] = circ.params['I']*circ.params['W']*circ.params['tauf']
             new_vars['trans_func'] = circ.ana.create_transfer_function()
         else:
             for key in ['tau_impulse', 'delta_f']:
                 new_vars[key] = circ.params[key]
             new_vars['H_df'] = circ.ana.create_H_df(new_vars, 'empirical')
-            new_vars['M'] = circ.params['I']*circ.params['W']
+            new_vars['M'] = circ.params['I']*circ.params['W']*circ.params['tauf']
 
         # copy of full connectivity (needed when connectivity is reduced)
         new_vars['M_full'] = new_vars['M']

--- a/test_circuit.py
+++ b/test_circuit.py
@@ -77,7 +77,7 @@ class TestCircuit(unittest.TestCase):
         params = {}
         params['tf_mode'] = 'empirical' 
         params['tau_impulse'] = np.array([8.555, 5.611, 4.167, 4.381, 4.131, 3.715, 4.538, 3.003])
-        params['delta_f'] = np.array([0.0880, 0.458, 0.749, 0.884, 1.183, 1.671, 0.140, 1.710])/self.net.params['w']
+        params['delta_f'] = np.array([0.0880, 0.458, 0.749, 0.884, 1.183, 1.671, 0.140, 1.710])/(self.net.params['w']*self.net.params['tauf'])
         net = circuit.Circuit('microcircuit', params)
         freqs, power = net.create_power_spectra()
         power_test = h5.load_h5(self.test_data, 'empirical/power')


### PR DESCRIPTION
In params_circuit.py, I defined the PSC 'w' independent of the synaptic time constant 'tauf' and adapted the firing rate integration and transfer function creation accordingly. This makes it easier to use the same parameters in simulations.

In analytics.py, I replaced all parameters accessed via the params dictionary by the class variables for consistency.